### PR TITLE
Updated errors in encoder.py, documentation in README and setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Welcome to Risknet! This is a downloadable Pip package where you can access and run an XGBoost pipeline.
 
+To access the Risknet package, you can download it by running `pip install risknet`. You can find documentation here: https://pypi.org/project/risknet/1.0.17/
+To access the Risknet code, fork the code from the Git repo.
+
 # Folder/File Layout Layout
 - src/risknet
    - `config`: holds `conf.yaml`

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In summary, the downloads needed for this code are:
 To update the version:
 1. Reset the code from the previous version (if necessary)
 - `rm -rf dist build` to remove build folder
-- manually remove "egg-info" folder. This will change `src` to `src/risknet`.
+- manually remove the "risknet.egg-info" folder. This will change `src` to `src/risknet`.
 2. Update setup.cfg's version number depending on if major, minor, or bug change
 3. Rerun `python3 -m build` (you should get a new dist folder + egg folder in \src)
    - THIS SHOULD CREATE A NEW binary file where version is UPDATED
@@ -122,3 +122,5 @@ But Running `>>> import risknet.utils.label_prep as label_prep, >>> label_prep.l
 0.0.14: change setup.py to `if __name__ == "__main__: setup()`.
 
 0.0.16: try compiling on base environment (python 3.12, pip 23.2)
+
+1.0.17: Uploading to PyPi as risknet! SUCCESS!! :D

--- a/README.md
+++ b/README.md
@@ -63,19 +63,24 @@ In summary, the downloads needed for this code are:
 - mypy
 - flake8
 
-# Steps to Update Version on TestPyPI
+# Steps to Update Version on TestPyPi
 To update the version:
 1. Reset the code from the previous version (if necessary)
 - `rm -rf dist build` to remove build folder
 - manually remove "egg-info" folder. This will change `src` to `src/risknet`.
 2. Update setup.cfg's version number depending on if major, minor, or bug change
-3. rerun `python3 -m build` (you should get a new dist folder + egg folder in \src)
+3. Rerun `python3 -m build` (you should get a new dist folder + egg folder in \src)
    - THIS SHOULD CREATE A NEW binary file where version is UPDATED
-4. rerun `python3 -m twine upload --repository testpypi dist/*`
+   - Make sure you're in the same directory as your setup.cfg when you run this command.
+4. Rerun `python3 -m twine upload --repository testpypi dist/*`
    - Username: `__token__`
    - Password: [testpypi password starting with pypi]
    - If you did NOT update the version # before running `build` then you will get an error
 
+# When Uploading to PyPi:
+Repeat steps above with these important differences:
+- Use `python3 -m twine upload dist/*` to upload to PyPi. You do not need to specify `--repository testpypi` when uploading to PyPi.
+- Login username will be the same. However, remember to use PyPi's login password/API token, **not** TestPyPi's token for the password.
 
 # Package Version History Documentation:
 0.0.1: Ran into problems with installing pytest-cov

--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ But Running `>>> import risknet.utils.label_prep as label_prep, >>> label_prep.l
 
 0.0.16: try compiling on base environment (python 3.12, pip 23.2)
 
-1.0.17: Uploading to PyPi as risknet! SUCCESS!! :D
+1.0.17: Uploading to PyPi as risknet! SUCCESS!! :D"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = risknet
-version = 0.0.17
+version = 1.0.17
 author = Zaki Ahmed, Rod Albuyeh, Terin Ambat, Emily Chin, Zhen Fang, Riya Mhatre, Zafeer Syed
 author_email = zahmed@ucsd.edu, albuyeh@gmail.com, tambat@ucsd.edu, e1chin@ucsd.edu, zhfang@ucsd.edu, rmhatre@ucsd.edu, zsyed@ucsd.edu
 description = A pip-installable pipeline which loads 2009 FM data into an XGBoost model instance
@@ -61,6 +61,6 @@ ignore = W191
 [tool:pytest]
 minversion = 6.0
 #pytest-cov had problems updating -- will comment out for now
-#addopts = -v --cov-report term --cov-report html:htmlcov --cov-report xml --cov-fail-under=5 --cov=pyspark_k8s_boilerplate
+addopts = -v --cov-report term --cov-report html:htmlcov --cov-report xml --cov-fail-under=5 --cov=pyspark_k8s_boilerplate
 testpaths =
     tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,9 @@ install_requires =
     types-PyYAML
     pyarrow
     fastparquet
+    scikit-learn
+    matplotlib
+    bayesian-optimization
 
 build_requires =
     pytest

--- a/src/risknet/proc/encoder.py
+++ b/src/risknet/proc/encoder.py
@@ -14,7 +14,7 @@ import reducer
 #Global Variables:
 numericals: List[str] = ['credit_score', 'number_of_units', 'orig_combined_loan_to_value', 'dti_ratio', 'original_unpaid_principal_balance', 'original_ltv', 'number_of_borrowers']
 categoricals: List[str] = ['first_time_homebuyer', 'occupancy_status', 'channel', 'prepayment_penalty_mortgage', 'product_type', 'property_type', 'loan_purpose', 'seller_name', 'servicer_name', 'super_conforming_flag']
-non_train_columns: List[str] = ['default', 'undefaurm -rf .git*lted_progress', 'flag']
+non_train_columns: List[str] = ['default', 'undefaulted_progress', 'flag', 'loan_sequence_number']
 
 #Functions:
 #Define datatypes
@@ -133,7 +133,7 @@ inputs:
 def scale(df, fm_root):
     '''Scaling'''
     train_columns: List[str] = [i for i in df.columns.to_list() if i not in non_train_columns]
-    train_columns.remove('loan_sequence_number') #This is not a numerical column so it can't be scaled with min/max subtraction
+    #train_columns.remove('loan_sequence_number') #This is not a numerical column so it can't be scaled with min/max subtraction
 
     train_mins = df.loc[df['flag'] == 'train'].loc[:, train_columns].min()
 

--- a/src/risknet/proc/reducer.py
+++ b/src/risknet/proc/reducer.py
@@ -58,7 +58,7 @@ class Reducer:
 
         if run_correlations:
             corr_matrix = df.corr().abs()
-            upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape),k=1).astype(np.bool))
+            upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape),k=1).astype(bool)) #Changed from numpy.bool to bool due to deprecation error
             high_corr = [column for column in upper.columns if any(upper[column] > corr_threshold)]
 
         self.varsToRemove = list(set(high_nulls + zero_vars + high_corr))

--- a/src/risknet/run/model.py
+++ b/src/risknet/run/model.py
@@ -60,6 +60,7 @@ class XGBCVTrain(object):
 
         logger.info("Define Evaluation Function")
 
+        #Evaluates XGB features and selects best values for HYPERparameters based on bayesian optimization
         def xgb_evaluate(eta, gamma, max_depth, min_child_weight, subsample, colsample_bytree, l_2, l_1, rounds):
             param = {'eta': eta,
                      'gamma': gamma,

--- a/src/risknet/run/pipeline.py
+++ b/src/risknet/run/pipeline.py
@@ -15,11 +15,13 @@ import pickle
 import logging
 logger = logging.getLogger("freelunch")
 
+import sys
+
 #User-Defined Imports:
+#sys.path.append(r"src/risknet/run")
 import model
 
 #Note: for some reason risknet.proc.[package_name] didn't work so I'm updating this yall :D
-import sys
 sys.path.append(r"src/risknet/proc") #reorient directory to access proc .py files
 import label_prep
 import reducer


### PR DESCRIPTION
For setup.cfg:

- Added packages like scikit-learn, bayesian_optimization, and matplotlib to setup.cfg. 
- Also updated the version number after successfully updated to PyPi

For README.md:

- Added more documentation/description of how to download risknet from PyPi + link

For model.py:

- Added comments/documentation about how hyperparameter tuning works

For encoder.py:

- Updated `non_train_columns` (see Slack message)

In reducer.py:
- Updated `.astype(np.bool)` to `.astype(bool)`